### PR TITLE
Hotfix/mixin stringify fix

### DIFF
--- a/lib/less-stringifier.js
+++ b/lib/less-stringifier.js
@@ -11,4 +11,8 @@ export default class LessStringifier extends Stringifier {
             this.builder(`/*${ left }${ node.text }${ right }*/`, node);
         }
     }
+    
+    mixin (node) {
+        this.builder(node.source.input.css);
+    }
 }

--- a/test/stringify.spec.js
+++ b/test/stringify.spec.js
@@ -49,4 +49,17 @@ describe('#stringify()', () => {
             expect(result).to.eql('// comment');
         });
     });
+    
+    describe('Mixins', () => {
+        it('stringifies mixins', () => {
+            const root = parse('.foo (@bar; @baz...) { border: @{baz}; }');
+            let result = '';
+
+            stringify(root, (i) => {
+                result += i;
+            });
+
+            expect(result).to.eql('.foo (@bar; @baz...) { border: @{baz}; }');
+        });
+    });
 });


### PR DESCRIPTION
part of the problem with [parsing mixins as at rules](https://github.com/webschik/postcss-less/issues/14) is that the stringifier breaks down (due to the subnodes of a mixin not being stringifiable). The main issue is that when an at rule is stringified it ends up loading the base (`postcss`) stringifier to handle the subnodes. In order to keep the subnodes in tact, we need to handle stringifying the mixin node specially. Here I am just using the full text of input.

This is a dependent PR for my next PR which will deal with the actual parsing of mixins as at rules.