### PR TITLE
Hotfix/mixins as at rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@
 
 A [LESS] parser for [PostCSS].
 
-**This module does not compile LESS.** It simply parses mixins as custom
-at-rules & variables as properties, so that PostCSS plugins can then transform
-LESS source code alongside CSS.
+**This module does not compile LESS.** It simply parses mixins and variables so that PostCSS plugins can then transform LESS source code alongside CSS.
 
 ## Use Cases
 
@@ -35,12 +33,20 @@ LESS source code alongside CSS.
 
 The main use case of this plugin is to apply PostCSS transformations directly
 to LESS source code. For example, if you ship a theme written in LESS and need
-[Autoprefixer] to add the appropriate vendor prefixes to it; or you need to
-lint LESS with a plugin such as [Stylelint].
+[Autoprefixer] to add the appropriate vendor prefixes to it.
 
 ```js
 const syntax = require('postcss-less');
 postcss(plugins).process(lessText, { syntax: syntax }).then(function (result) {
+    result.content // LESS with transformations
+});
+```
+
+When you want to lint LESS with a plugin such as [Stylelint], you will need to tell `postcss-less` to _fake_ LESS-specific syntax.
+
+```js
+const syntax = require('postcss-less');
+postcss().process(lessText, { syntax: syntax, mixinsAsAtRules: true }).then(function (result) {
     result.content // LESS with transformations
 });
 ```

--- a/lib/less-parse.js
+++ b/lib/less-parse.js
@@ -4,7 +4,7 @@ import LessParser from './less-parser';
 
 export default function lessParse (less, opts) {
     const input = new Input(less, opts);
-    const parser = new LessParser(input);
+    const parser = new LessParser(input, opts);
 
     parser.tokenize();
     parser.loop();

--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -7,7 +7,7 @@ import lessTokenizer from './less-tokenize';
 const MixinDefinitionPattern = /^([#.](?:[\w-]|\\(?:[A-Fa-f0-9]{1,6} ?|[^A-Fa-f0-9]))+)\s*\(/;
 
 export default class LessParser extends Parser {
-    constructor (input) {
+    constructor (input, opts) {
         super(input);
         this.mixins = {};
     }

--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -10,6 +10,7 @@ export default class LessParser extends Parser {
     constructor (input, opts) {
         super(input);
         this.mixins = {};
+        this.mixinsAsAtRules = (opts || {}).mixinsAsAtRules;
     }
 
     tokenize () {
@@ -48,7 +49,14 @@ export default class LessParser extends Parser {
         if (MixinDefinitionPattern.test(this.current.source.input.css)) {
             // this.current is the 'rule' node created in super.rule()
             this.current.name = token[0][1].slice(1);
-            this.current.type = 'mixin';
+            
+            if (this.mixinsAsAtRules === true) {
+                this.current.type = 'atrule';
+                this.current.lessType = 'mixin';
+            } else {
+                this.current.type = 'mixin';
+            }
+            
             this.current.definition = true;
             this.current.params = [];
 

--- a/lib/less-stringifier.js
+++ b/lib/less-stringifier.js
@@ -12,6 +12,14 @@ export default class LessStringifier extends Stringifier {
         }
     }
     
+    atrule (node, semicolon) {
+        if (node.lessType === 'mixin') {
+            this.mixin(node);
+        } else {
+            super.atrule(node, semicolon);
+        }
+    }
+    
     mixin (node) {
         this.builder(node.source.input.css);
     }

--- a/test/parser/mixins.spec.js
+++ b/test/parser/mixins.spec.js
@@ -18,6 +18,12 @@ describe('Parser', () => {
             expect(root.first.first.prop).to.eql('border');
             expect(root.first.first.value).to.eql('@{baz}');
         });
+        
+        it('can parse basic mixins as at rules', () => {
+            const root = parse('.foo (@bar; @baz...) { border: @{baz}; }', {mixinsAsAtRules: true});
+
+            expect(root.first.type).to.eql('atrule');
+        });
 
         describe('Nested mixin', () => {
             /* eslint-disable no-multiple-empty-lines */

--- a/test/postcss.spec.js
+++ b/test/postcss.spec.js
@@ -19,4 +19,18 @@ describe('#postcss', () => {
                 done();
             });
     });
+    
+    it('can parse LESS mixins as at rules', (done) => {
+        const lessText = '.foo (@bar; @baz...) { border: @{baz}; }';
+
+        postcss()
+            .process(lessText, {syntax: lessSyntax, mixinsAsAtRules: true})
+            .then((result) => {
+                expect(result).to.be.not.null;
+                expect(result.css).to.equal(lessText);
+                expect(result.content).to.equal(lessText);
+                
+                done();
+            });
+    });
 });


### PR DESCRIPTION
Here is the big one. Allows mixins to be parsed as at rules as an opt-in flag. This will bring support into stylelint and (essentially) resolve #14.

One thing to note, as I have been looking at this, perhaps instead of a flag to fix `mixin` nodes, a better strategy is just a generic `stylelint` flag that could be used to deal with other node types as well? easy to fix if you like that better.