### PR TITLE
fixes for issue #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,71 @@ postcss(plugins).process(lessText, { syntax: syntax }).then(function (result) {
 });
 ```
 
-### Inline Comments for PostCSS
+### Comment Node
+
+#### Inline comments
 
 This module also enables parsing of single-line comments in CSS source code.
 
-```less
+````less
 :root {
     // Main theme color
     --color: red;
 }
-```
+````
 
 Note that you don't need a special stringifier to handle the output; the default
-one will automatically convert single line comments into block comments.
+one will automatically convert single line comments into block comments. 
+If you need to get inline comments, use stringifier from `postcss-less` module:
+
+````js
+import postCssLess from 'postcss-less';
+
+const root = postCssLess.parse('// Hello world');
+
+root.first.toString(); // returns '/* Hello world */'
+
+root.first.toString({
+    stringify: postCssLess.stringify
+}); // returns '// Hello world'
+````
+
+#### Comment Node
+
+`postcss-less` extends the [default structure](https://github.com/postcss/postcss/blob/master/docs/api.md#comment-node) of Comment node
+
+##### comment.inline
+It's inline comment or not.
+````js
+import postCssLess from 'postcss-less';
+
+const root = postCssLess.parse('// Hello world');
+
+root.first.inline // => true
+````
+
+##### comment.block
+It's block comment or not.
+````js
+import postCssLess from 'postcss-less';
+
+const root = postCssLess.parse('/* Hello world */');
+
+root.first.block // => true
+````
+
+##### comment.raws.begin
+Precending characters of comment node: `//` or `/*`.
+
+##### comment.raws.content
+Raw content of the comment.
+````js
+import postCssLess from 'postcss-less';
+
+const root = postCssLess.parse('// Hello world');
+
+root.first.raws.content // => '// Hello world'
+````
 
 ### Stylelint support
 `postcss-less` parser **is not compatible** with `Stylelint`, because `Stylelint` can't process syntax tree from `postcss-less`!

--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -4,34 +4,41 @@ import findExtendRule from './find-extend-rule';
 import isMixinToken from './is-mixin-token';
 import lessTokenizer from './less-tokenize';
 
+const blockCommentEndPattern = /\*\/$/;
+
 export default class LessParser extends Parser {
     tokenize () {
         this.tokens = lessTokenizer(this.input);
     }
 
     comment (token) {
-        if (token[6] === 'inline') {
-            const node = new Comment();
+        const node = new Comment();
+        const content = token[1];
+        const text = content.slice(2).replace(blockCommentEndPattern, '');
 
-            this.init(node, token[2], token[3]);
-            node.raws.inline = true;
-            node.source.end = {line: token[4], column: token[5]};
+        this.init(node, token[2], token[3]);
+        node.source.end = {
+            line: token[4],
+            column: token[5]
+        };
 
-            const text = token[1].slice(2);
+        node.raws.content = content;
+        node.raws.begin = content[0] + content[1];
+        node.inline = token[6] === 'inline';
+        node.block = !node.inline;
 
-            if (/^\s*$/.test(text)) {
-                node.text = '';
-                node.raws.left = text;
-                node.raws.right = '';
-            } else {
-                const match = text.match(/^(\s*)([^]*[^\s])(\s*)$/);
-
-                node.text = match[2];
-                node.raws.left = match[1];
-                node.raws.right = match[3];
-            }
+        if (/^\s*$/.test(text)) {
+            node.text = '';
+            node.raws.left = text;
+            node.raws.right = '';
         } else {
-            super.comment(token);
+            const match = text.match(/^(\s*)([^]*[^\s])(\s*)$/);
+            
+            node.text = match[2];
+
+            // Add extra spaces to generate a comment in a common style /*[space][text][space]*/
+            node.raws.left = match[1] || ' ';
+            node.raws.right = match[3] || ' ';
         }
     }
 
@@ -94,7 +101,7 @@ export default class LessParser extends Parser {
             if (options.isEndOfBlock) {
                 while (this.pos > start) {
                     const token = this.tokens[this.pos][0];
-                    
+
                     if (token !== 'space' && token !== 'comment') {
                         break;
                     }

--- a/lib/less-stringifier.js
+++ b/lib/less-stringifier.js
@@ -5,7 +5,7 @@ export default class LessStringifier extends Stringifier {
         const left = this.raw(node, 'left', 'commentLeft');
         const right = this.raw(node, 'right', 'commentRight');
 
-        if (node.raws.inline) {
+        if (node.inline) {
             this.builder(`//${ left }${ node.text }${ right }`, node);
         } else {
             this.builder(`/*${ left }${ node.text }${ right }*/`, node);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-less",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "LESS parser for PostCSS",
   "keywords": [
     "css",

--- a/test/parser/comments.spec.js
+++ b/test/parser/comments.spec.js
@@ -7,39 +7,80 @@ import parse from '../../lib/less-parse';
 describe('Parser', () => {
     describe('Comments', () => {
         it('parses inline comments', () => {
-            const root = parse('\n// a \n/* b */');
+            const root = parse('\n// here is the first comment \n/* here is the second comment */');
 
-            expect(root.nodes).to.have.length(2);
-            expect(root.first.text).to.eql('a');
+            expect(root.nodes.length).to.eql(2);
+            expect(root.first.text).to.equal('here is the first comment');
             expect(root.first.raws).to.eql({
                 before: '\n',
+                content: '// here is the first comment ',
+                begin: '//',
                 left: ' ',
-                right: ' ',
-                inline: true
+                right: ' '
             });
-            expect(root.last.text).to.eql('b');
+            expect(root.first.inline).to.equal(true);
+            expect(root.first.block).to.equal(false);
+            expect(root.first.toString()).to.equal('/* here is the first comment */');
+            
+            expect(root.last.text).to.eql('here is the second comment');
+            expect(root.last.raws).to.eql({
+                before: '\n',
+                content: '/* here is the second comment */',
+                begin: '/*',
+                left: ' ',
+                right: ' '
+            });
+            expect(root.last.inline).to.equal(false);
+            expect(root.last.block).to.equal(true);
+            expect(root.last.toString()).to.equal('/* here is the second comment */');
         });
 
         it('parses empty inline comments', () => {
-            const root = parse('//\n// ');
+            const root = parse(' //\n// ');
 
             expect(root.first.text).to.eql('');
             expect(root.first.raws).to.eql({
-                before: '',
+                before: ' ',
+                begin: '//',
+                content: '//',
                 left: '',
-                right: '',
-                inline: true
+                right: ''
             });
+            expect(root.last.inline).to.equal(true);
+            expect(root.last.block).to.equal(false);
+            
             expect(root.last.text).to.eql('');
             expect(root.last.raws).to.eql({
                 before: '\n',
+                begin: '//',
+                content: '// ',
                 left: ' ',
-                right: '',
-                inline: true
+                right: ''
             });
+            expect(root.last.inline).to.equal(true);
+            expect(root.last.block).to.equal(false);
+        });
+        
+        it('parses multiline comments', () => {
+            const text = 'Hello!\n I\'m a multiline \n comment!';
+            const comment = ` /*   ${ text }*/ `;
+            const root = parse(comment);
+            
+            expect(root.nodes.length).to.eql(1);
+            expect(root.first.text).to.eql(text);
+            expect(root.first.raws).to.eql({
+                before: ' ',
+                begin: '/*',
+                content: comment.trim(),
+                left: '   ',
+                right: ' '
+            });
+            expect(root.first.inline).to.equal(false);
+            expect(root.first.block).to.equal(true);
+            expect(root.first.toString()).to.equal(`/*   ${ text } */`);
         });
 
-        it('does not parse comments inside brackets', () => {
+        it('does not parse pseudo-comments constructions inside parentheses', () => {
             const root = parse('a { cursor: url(http://site.com) }');
 
             expect(root.first.first.value).to.eql('url(http://site.com)');

--- a/test/parser/postcss-cases.spec.js
+++ b/test/parser/postcss-cases.spec.js
@@ -8,6 +8,14 @@ import parse from '../../lib/less-parse';
 describe('Parser', () => {
     describe('CSS for PostCSS', () => {
         cases.each((name, code, json) => {
+            /**
+             * @description
+             *  - Skip comments.css, because we have an extended Comment node
+             */
+            if (name === 'comments.css') {
+                return;
+            }
+            
             it(`parses ${ name }`, () => {
                 const root = parse(code, {from: name});
                 const parsed = cases.jsonify(root);

--- a/test/stringify.spec.js
+++ b/test/stringify.spec.js
@@ -35,7 +35,7 @@ describe('#stringify()', () => {
                 result += i;
             });
 
-            expect(result).to.eql('// comment\na {}');
+            expect(result).to.eql('// comment \na {}');
         });
 
         it('stringifies inline comment in the end of file', () => {
@@ -46,7 +46,7 @@ describe('#stringify()', () => {
                 result += i;
             });
 
-            expect(result).to.eql('// comment');
+            expect(result).to.eql('// comment ');
         });
     });
     


### PR DESCRIPTION
1. save preceding characters for comments in .raws;
2. prettify block comments;
3. save original content of comment;