### PR TITLE
expanding the inline flag to the raws structure as well

### DIFF
--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -24,7 +24,7 @@ export default class LessParser extends Parser {
 
         node.raws.content = content;
         node.raws.begin = content[0] + content[1];
-        node.inline = token[6] === 'inline';
+        node.raws.inline = node.inline = token[6] === 'inline';
         node.block = !node.inline;
 
         if (/^\s*$/.test(text)) {

--- a/test/parser/comments.spec.js
+++ b/test/parser/comments.spec.js
@@ -15,6 +15,7 @@ describe('Parser', () => {
                 before: '\n',
                 content: '// here is the first comment ',
                 begin: '//',
+                inline: true,
                 left: ' ',
                 right: ' '
             });
@@ -27,6 +28,7 @@ describe('Parser', () => {
                 before: '\n',
                 content: '/* here is the second comment */',
                 begin: '/*',
+                inline: false,
                 left: ' ',
                 right: ' '
             });
@@ -43,6 +45,7 @@ describe('Parser', () => {
                 before: ' ',
                 begin: '//',
                 content: '//',
+                inline: true,
                 left: '',
                 right: ''
             });
@@ -54,6 +57,7 @@ describe('Parser', () => {
                 before: '\n',
                 begin: '//',
                 content: '// ',
+                inline: true,
                 left: ' ',
                 right: ''
             });
@@ -72,6 +76,7 @@ describe('Parser', () => {
                 before: ' ',
                 begin: '/*',
                 content: comment.trim(),
+                inline: false,
                 left: '   ',
                 right: ' '
             });


### PR DESCRIPTION
stylelint's `comment-empty-line-before` rule is checking `node.raws.inline` for inline comments, so this patch will allow inline comments to be ignored properly.