### PR TITLE
Use the whole dist folder when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "main": "dist/less-syntax.js",
   "files": [
-    "dist/*.js"
+    "dist"
   ],
   "author": "Denys Kniazevych <webschik@gmail.com>",
   "contributors": [


### PR DESCRIPTION
Related to #40, just use the whole `dist` folder when publishing to `npm`.