### PR TITLE
build error is masked in gulp task test:run

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -127,7 +127,12 @@ gulp.task('test:run', ['build:test'], () => {
         .src(path.join(config.dirs.build, config.builds.test, '**', '*.spec.js'), {read: false})
         .pipe(mocha({
             reporter: config.test.reporter
-        }));
+        }))
+        .on('error', function (error) {
+            util.log(error);
+            // eslint-disable-next-line no-invalid-this
+            this.emit('end');
+        });
 });
 
 gulp.task('test:integration', ['build:lib'], (done) => {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -127,11 +127,7 @@ gulp.task('test:run', ['build:test'], () => {
         .src(path.join(config.dirs.build, config.builds.test, '**', '*.spec.js'), {read: false})
         .pipe(mocha({
             reporter: config.test.reporter
-        }))
-        .on('error', function () {
-            // eslint-disable-next-line no-invalid-this
-            this.emit('end');
-        });
+        }));
 });
 
 gulp.task('test:integration', ['build:lib'], (done) => {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -123,15 +123,25 @@ gulp.task('test:all', (done) => {
 });
 
 gulp.task('test:run', ['build:test'], () => {
+    let mochaError = {};
+
     return gulp
         .src(path.join(config.dirs.build, config.builds.test, '**', '*.spec.js'), {read: false})
         .pipe(mocha({
             reporter: config.test.reporter
         }))
         .on('error', function (error) {
-            util.log(error);
+            mochaError = error;
             // eslint-disable-next-line no-invalid-this
             this.emit('end');
+        })
+        .on('end', () => {
+            if (mochaError.message) {
+                throw new util.PluginError({
+                    plugin: 'gulp-mocha',
+                    message: mochaError.message
+                });
+            }
         });
 });
 

--- a/test/stringify.spec.js
+++ b/test/stringify.spec.js
@@ -5,8 +5,8 @@ import cases from 'postcss-parser-tests';
 import {expect} from 'chai';
 import parse from './../lib/less-parse';
 import postcss from 'postcss';
-import postcssLess from 'postcss-less';
-import stringify from 'postcss-less/less-stringify';
+import postcssLess from './../lib/less-syntax';
+import stringify from './../lib/less-stringify';
 
 describe('#stringify()', () => {
     describe('CSS for PostCSS', () => {
@@ -103,7 +103,7 @@ describe('#stringify()', () => {
                         width: @width;
                     }
                 }
-                
+
                 .rotation(@deg:5deg){
                   .transform(rotate(@deg));
                 }


### PR DESCRIPTION
The gulp task test:run, is masking a failing build. In https://github.com/ChrisEbert/postcss-less/commit/dc8d565ed91c7d8034a6d2fdef58748495287b54 I removed the error handler, to see the build failing - https://travis-ci.org/ChrisEbert/postcss-less/jobs/139579980

I fixed that issue in this pull request, but now there is a failing unit test - https://travis-ci.org/ChrisEbert/postcss-less/jobs/139611400

Are you interested in these changes? Until now, I was not able to fix the unit test in addition.